### PR TITLE
feat: variables use

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -78,7 +78,15 @@
     "submitButton": "Send",
     "inputError": "URL is required",
     "requestSuccess": "Request completed successfully",
-    "requestFailed": "Request failed: "
+    "requestFailed": "Request failed: ",
+    "headers": "Headers",
+    "body": "Body",
+    "response": "Response",
+    "variablesInfo": "Variables Information",
+    "variablesFormat": "Use variables with format:",
+    "availableVariables": "Available variables:",
+    "containsVariables": "Contains variables that will be interpolated",
+    "noResponse": "No response yet. Send a request to see results."
   },
   "HistoryPage": {},
   "VariablesPage": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -104,5 +104,21 @@
     "valueRequired": "Value is required",
     "invalidValue": "Invalid value",
     "errorText": "Error message"
+  },
+  "CodeGenerator": {
+    "generateCodeButton": "Generate Code",
+    "modalTitle": "Generated Code",
+    "closeButton": "Close",
+    "generatingCode": "Generating code...",
+    "codeNotAvailable": "Code not available",
+    "generatingAllLanguages": "Generating code for all languages...",
+    "codeForRequest": "Code for {method} request ({language}):",
+    "invalidJsonHeaders": "Invalid JSON in headers",
+    "interpolationError": "Interpolation error",
+    "unresolvedVariablesError": "Error: Unresolved variables detected: {vars}",
+    "invalidHeadersFormat": "Error: Invalid headers format",
+    "generationError": "Error generating {lang} code: {error}",
+    "generalGenerationError": "Error generating codes: {error}",
+    "unknownError": "Unknown error"
   }
 }

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -78,7 +78,15 @@
     "submitButton": "Отправить",
     "inputError": "URL обязателен для заполнения",
     "requestSuccess": "Запрос успешно выполнен",
-    "requestFailed": "Ошибка запроса: "
+    "requestFailed": "Ошибка запроса: ",
+    "headers": "Заголовки",
+    "body": "Тело",
+    "response": "Ответ",
+    "variablesInfo": "Информация о переменных",
+    "variablesFormat": "Используйте переменные в формате:",
+    "availableVariables": "Доступные переменные:",
+    "containsVariables": "Содержит переменные, которые будут интерполированы",
+    "noResponse": "Ответа пока что нетути. Отправьте запрос, чтобы увидеть результаты."
   },
   "HistoryPage": {},
   "VariablesPage": {

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -104,5 +104,21 @@
     "valueRequired": "Значение обязательно",
     "invalidValue": "Неверное значение",
     "errorText": "Сообщение об ошибке"
+  },
+  "CodeGenerator": {
+    "generateCodeButton": "Сгенерировать код",
+    "modalTitle": "Сгенерированный код",
+    "closeButton": "Закрыть",
+    "generatingCode": "Генерация кода...",
+    "codeNotAvailable": "Код недоступен",
+    "generatingAllLanguages": "Генерация кода для всех языков...",
+    "codeForRequest": "Код для {method} запроса ({language}):",
+    "invalidJsonHeaders": "Неверный JSON в заголовках",
+    "interpolationError": "Ошибка интерполяции",
+    "unresolvedVariablesError": "Ошибка: Обнаружены неразрешенные переменные: {vars}",
+    "invalidHeadersFormat": "Ошибка: Неверный формат заголовков",
+    "generationError": "Ошибка генерации кода для {lang}: {error}",
+    "generalGenerationError": "Ошибка генерации кодов: {error}",
+    "unknownError": "Неизвестная ошибка"
   }
 }

--- a/src/components/CodeGenerator/CodeGenerator.module.css
+++ b/src/components/CodeGenerator/CodeGenerator.module.css
@@ -10,6 +10,7 @@
   display: flex;
   flex-direction: column;
   gap: 16px;
+  min-height: 400px;
 }
 
 .select {
@@ -32,5 +33,13 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  height: 100px;
+  height: 200px;
+  color: #1890ff;
+  flex-direction: column;
+}
+
+.error-message {
+  color: #ff4d4f;
+  text-align: center;
+  padding: 20px;
 }

--- a/src/components/CodeGenerator/CodeGenerator.tsx
+++ b/src/components/CodeGenerator/CodeGenerator.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import React, { useState, useCallback } from 'react';
-import { Modal, Button, Select, Input, Typography, message } from 'antd';
+import React, { useState, useMemo } from 'react';
+import { Button } from 'antd';
 import { CodeOutlined } from '@ant-design/icons';
-import { generateCode } from '@/utils/codeGenerator';
+import { useTranslations } from 'next-intl';
 import {
   interpolateVariables,
   loadVariablesFromStorage,
@@ -11,10 +11,7 @@ import {
   Variable,
 } from '@/utils/variablesUtils';
 import styles from './CodeGenerator.module.css';
-
-const { Option } = Select;
-const { TextArea } = Input;
-const { Title } = Typography;
+import CodeGeneratorModal from './CodeGeneratorModal';
 
 interface CodeGeneratorProps {
   method: string;
@@ -24,16 +21,16 @@ interface CodeGeneratorProps {
   variables?: Variable[];
 }
 
-const codeLanguages = [
-  { value: 'curl', label: 'cURL' },
-  { value: 'javascript-fetch', label: 'JavaScript (Fetch)' },
-  { value: 'javascript-xhr', label: 'JavaScript (XHR)' },
-  { value: 'nodejs', label: 'Node.js' },
-  { value: 'python', label: 'Python' },
-  { value: 'java', label: 'Java' },
-  { value: 'csharp', label: 'C#' },
-  { value: 'go', label: 'Go' },
-];
+// Выносим константы наружу - они никогда не меняются
+const ERROR_MESSAGES = {
+  invalidJsonHeaders: 'Invalid JSON in headers',
+  interpolationError: 'Error interpolating variables',
+  unresolvedVariablesError: 'Unresolved variables: {vars}',
+  invalidHeadersFormat: 'Invalid headers format',
+  generationError: 'Error generating {lang} code: {error}',
+  unknownError: 'Unknown error',
+  generalGenerationError: 'Error generating code: {error}',
+};
 
 export default function CodeGenerator({
   method,
@@ -42,78 +39,71 @@ export default function CodeGenerator({
   body,
   variables: externalVariables = [],
 }: CodeGeneratorProps) {
+  const t = useTranslations('CodeGenerator');
   const [isModalVisible, setIsModalVisible] = useState(false);
-  const [generatedCode, setGeneratedCode] = useState('');
-  const [selectedLanguage, setSelectedLanguage] = useState('curl');
-  const [loading, setLoading] = useState(false);
 
-  const variables =
-    externalVariables.length > 0
-      ? externalVariables
-      : loadVariablesFromStorage();
+  const variables = useMemo(
+    () =>
+      externalVariables.length > 0
+        ? externalVariables
+        : loadVariablesFromStorage(),
+    [externalVariables]
+  );
 
-  const handleGenerateCode = useCallback(() => {
+  // Вычисляем интерполированные значения один раз при открытии модалки
+  const interpolatedValues = useMemo(() => {
     try {
-      setLoading(true);
-
       let parsedHeaders = {};
       try {
         parsedHeaders = JSON.parse(headers || '{}');
       } catch {
-        message.error('Invalid JSON in headers');
-        return;
+        return {
+          interpolatedUrl: url,
+          interpolatedHeaders: headers,
+          interpolatedBody: body,
+          hasUnresolvedVars: true,
+          unresolvedVars: [ERROR_MESSAGES.invalidJsonHeaders],
+        };
       }
 
-      const interpolatedUrl = interpolateVariables(url, variables);
-      const interpolatedHeaders = interpolateVariables(
+      const interpolatedUrlValue = interpolateVariables(url, variables);
+      const interpolatedHeadersValue = interpolateVariables(
         JSON.stringify(parsedHeaders),
         variables
       );
-      const interpolatedBody = interpolateVariables(body, variables);
+      const interpolatedBodyValue = interpolateVariables(body, variables);
 
-      const unresolvedVars = [
-        ...extractVariableNames(interpolatedUrl),
-        ...extractVariableNames(interpolatedHeaders),
-        ...extractVariableNames(interpolatedBody),
+      const unresolvedVarsList = [
+        ...extractVariableNames(interpolatedUrlValue),
+        ...extractVariableNames(interpolatedHeadersValue),
+        ...extractVariableNames(interpolatedBodyValue),
       ];
 
-      if (unresolvedVars.length > 0) {
-        message.error(`Unresolved variables: ${unresolvedVars.join(', ')}`);
-        return;
-      }
-
-      let finalHeaders = {};
-      try {
-        finalHeaders = JSON.parse(interpolatedHeaders || '{}');
-      } catch {
-        message.error('Invalid JSON in headers after variable interpolation');
-        return;
-      }
-
-      const code = generateCode(
-        selectedLanguage,
-        method,
-        interpolatedUrl,
-        finalHeaders,
-        interpolatedBody
-      );
-      setGeneratedCode(code);
+      return {
+        interpolatedUrl: interpolatedUrlValue,
+        interpolatedHeaders: interpolatedHeadersValue,
+        interpolatedBody: interpolatedBodyValue,
+        hasUnresolvedVars: unresolvedVarsList.length > 0,
+        unresolvedVars: unresolvedVarsList,
+      };
     } catch (error) {
-      console.error('Error generating code:', error);
-      message.error('Failed to generate code');
-    } finally {
-      setLoading(false);
+      console.error('Error interpolating variables:', error);
+      return {
+        interpolatedUrl: url,
+        interpolatedHeaders: headers,
+        interpolatedBody: body,
+        hasUnresolvedVars: true,
+        unresolvedVars: [ERROR_MESSAGES.interpolationError],
+      };
     }
-  }, [method, url, headers, body, variables, selectedLanguage]);
+  }, [url, headers, body, variables]);
 
   const handleOpenModal = () => {
     setIsModalVisible(true);
-    handleGenerateCode();
   };
 
-  const handleLanguageChange = (value: string) => {
-    setSelectedLanguage(value);
-    handleGenerateCode();
+  const handleCloseModal = () => {
+    setIsModalVisible(false);
   };
 
   return (
@@ -122,48 +112,27 @@ export default function CodeGenerator({
         icon={<CodeOutlined />}
         onClick={handleOpenModal}
         className={styles.button}
-        loading={loading}
       >
-        Generate Code
+        {t('generateCodeButton')}
       </Button>
 
-      <Modal
-        title="Generated Code"
-        open={isModalVisible}
-        onCancel={() => setIsModalVisible(false)}
-        footer={[
-          <Button key="close" onClick={() => setIsModalVisible(false)}>
-            Close
-          </Button>,
-        ]}
-        width={800}
-        className={styles.modal}
-      >
-        <div className={styles['modal-content']}>
-          <Select
-            value={selectedLanguage}
-            onChange={handleLanguageChange}
-            className={styles.select}
-          >
-            {codeLanguages.map((lang) => (
-              <Option key={lang.value} value={lang.value}>
-                {lang.label}
-              </Option>
-            ))}
-          </Select>
-
-          <Title level={5} className={styles['code-title']}>
-            Code for {method} request:
-          </Title>
-
-          <TextArea
-            value={generatedCode}
-            readOnly
-            rows={15}
-            className={styles['text-area']}
-          />
-        </div>
-      </Modal>
+      {isModalVisible && (
+        <CodeGeneratorModal
+          isVisible={isModalVisible}
+          onClose={handleCloseModal}
+          method={method}
+          interpolatedValues={interpolatedValues}
+          errorMessages={ERROR_MESSAGES}
+          translations={{
+            modalTitle: t('modalTitle'),
+            closeButton: t('closeButton'),
+            generatingCode: t('generatingCode'),
+            codeNotAvailable: t('codeNotAvailable'),
+            generatingAllLanguages: t('generatingAllLanguages'),
+            codeForRequestTemplate: 'Code for {method} request ({language}):',
+          }}
+        />
+      )}
     </>
   );
 }

--- a/src/components/CodeGenerator/CodeGeneratorModal.tsx
+++ b/src/components/CodeGenerator/CodeGeneratorModal.tsx
@@ -1,0 +1,243 @@
+'use client';
+
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { Modal, Button, Select, Input, Typography, Spin } from 'antd';
+import { generateCode } from '@/utils/codeGenerator';
+import styles from './CodeGenerator.module.css';
+
+const { Option } = Select;
+const { TextArea } = Input;
+const { Title } = Typography;
+
+interface CodeGeneratorModalProps {
+  isVisible: boolean;
+  onClose: () => void;
+  method: string;
+  interpolatedValues: {
+    interpolatedUrl: string;
+    interpolatedHeaders: string;
+    interpolatedBody: string;
+    hasUnresolvedVars: boolean;
+    unresolvedVars: string[];
+  };
+  errorMessages: {
+    unresolvedVariablesError: string;
+    invalidHeadersFormat: string;
+    generationError: string;
+    unknownError: string;
+    generalGenerationError: string;
+  };
+  translations: {
+    modalTitle: string;
+    closeButton: string;
+    generatingCode: string;
+    codeNotAvailable: string;
+    generatingAllLanguages: string;
+    codeForRequestTemplate: string;
+  };
+}
+
+interface GeneratedCodes {
+  [key: string]: string;
+}
+
+const codeLanguages = [
+  { value: 'curl', label: 'cURL' },
+  { value: 'javascript-fetch', label: 'JavaScript (Fetch)' },
+  { value: 'javascript-xhr', label: 'JavaScript (XHR)' },
+  { value: 'nodejs', label: 'Node.js' },
+  { value: 'python', label: 'Python' },
+  { value: 'java', label: 'Java' },
+  { value: 'csharp', label: 'C#' },
+  { value: 'go', label: 'Go' },
+];
+
+export default function CodeGeneratorModal({
+  isVisible,
+  onClose,
+  method,
+  interpolatedValues,
+  errorMessages,
+  translations,
+}: CodeGeneratorModalProps) {
+  const [selectedLanguage, setSelectedLanguage] = useState('curl');
+  const [generatedCodes, setGeneratedCodes] = useState<GeneratedCodes>({});
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [generationError, setGenerationError] = useState<string>('');
+  const isGeneratingRef = useRef(false);
+  const interpolatedValuesRef = useRef(interpolatedValues);
+  const methodRef = useRef(method);
+  const errorMessagesRef = useRef(errorMessages);
+
+  // Update refs when props change
+  useEffect(() => {
+    interpolatedValuesRef.current = interpolatedValues;
+    methodRef.current = method;
+    errorMessagesRef.current = errorMessages;
+  }, [interpolatedValues, method, errorMessages]);
+
+  const generateAllCodes = useCallback(async () => {
+    if (isGeneratingRef.current) return;
+
+    isGeneratingRef.current = true;
+    setIsGenerating(true);
+    setGenerationError('');
+
+    const {
+      interpolatedUrl,
+      interpolatedHeaders,
+      interpolatedBody,
+      hasUnresolvedVars,
+      unresolvedVars,
+    } = interpolatedValuesRef.current;
+
+    try {
+      if (hasUnresolvedVars) {
+        const errorMessage =
+          errorMessagesRef.current.unresolvedVariablesError.replace(
+            '{vars}',
+            unresolvedVars.join(', ')
+          );
+        const errorCodes: GeneratedCodes = {};
+        codeLanguages.forEach((lang) => {
+          errorCodes[lang.value] = errorMessage;
+        });
+        setGeneratedCodes(errorCodes);
+        setGenerationError(errorMessage);
+        return;
+      }
+
+      let finalHeaders = {};
+      try {
+        finalHeaders = JSON.parse(interpolatedHeaders || '{}');
+      } catch {
+        const errorMessage = errorMessagesRef.current.invalidHeadersFormat;
+        const errorCodes: GeneratedCodes = {};
+        codeLanguages.forEach((lang) => {
+          errorCodes[lang.value] = errorMessage;
+        });
+        setGeneratedCodes(errorCodes);
+        setGenerationError(errorMessage);
+        return;
+      }
+
+      const codes: GeneratedCodes = {};
+
+      for (const lang of codeLanguages) {
+        try {
+          const code = generateCode(
+            lang.value,
+            methodRef.current,
+            interpolatedUrl,
+            finalHeaders,
+            interpolatedBody
+          );
+          codes[lang.value] = code;
+        } catch (error) {
+          codes[lang.value] = errorMessagesRef.current.generationError
+            .replace('{lang}', lang.label)
+            .replace(
+              '{error}',
+              error instanceof Error
+                ? error.message
+                : errorMessagesRef.current.unknownError
+            );
+        }
+      }
+
+      setGeneratedCodes(codes);
+    } catch (error) {
+      const errorMessage =
+        errorMessagesRef.current.generalGenerationError.replace(
+          '{error}',
+          error instanceof Error
+            ? error.message
+            : errorMessagesRef.current.unknownError
+        );
+      const errorCodes: GeneratedCodes = {};
+      codeLanguages.forEach((lang) => {
+        errorCodes[lang.value] = errorMessage;
+      });
+      setGeneratedCodes(errorCodes);
+      setGenerationError(errorMessage);
+    } finally {
+      setIsGenerating(false);
+      isGeneratingRef.current = false;
+    }
+  }, []); // Empty dependency array since we use refs
+
+  useEffect(() => {
+    if (!isVisible) return;
+    generateAllCodes();
+  }, [isVisible, generateAllCodes]); // generateAllCodes is now stable
+
+  const handleLanguageChange = (value: string) => {
+    setSelectedLanguage(value);
+  };
+
+  const currentCode = isGenerating
+    ? translations.generatingCode
+    : generationError
+      ? generationError
+      : generatedCodes[selectedLanguage] || translations.codeNotAvailable;
+
+  const languageLabel =
+    codeLanguages.find((lang) => lang.value === selectedLanguage)?.label || '';
+
+  return (
+    <Modal
+      title={translations.modalTitle}
+      open={isVisible}
+      onCancel={onClose}
+      footer={[
+        <Button key="close" onClick={onClose}>
+          {translations.closeButton}
+        </Button>,
+      ]}
+      width={800}
+      className={styles.modal}
+    >
+      <div className={styles['modal-content']}>
+        <Select
+          value={selectedLanguage}
+          onChange={handleLanguageChange}
+          className={styles.select}
+          loading={isGenerating}
+          disabled={isGenerating || !!generationError}
+        >
+          {codeLanguages.map((lang) => (
+            <Option key={lang.value} value={lang.value}>
+              {lang.label}
+            </Option>
+          ))}
+        </Select>
+
+        {isGenerating && (
+          <div className={styles['loading-indicator']}>
+            <Spin size="large" />
+            <span style={{ marginLeft: 8 }}>
+              {translations.generatingAllLanguages}
+            </span>
+          </div>
+        )}
+
+        {!isGenerating && (
+          <>
+            <Title level={5} className={styles['code-title']}>
+              {translations.codeForRequestTemplate
+                .replace('{method}', method)
+                .replace('{language}', languageLabel)}
+            </Title>
+
+            <TextArea
+              value={currentCode}
+              readOnly
+              rows={15}
+              className={styles['text-area']}
+            />
+          </>
+        )}
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/Header/styles.module.css
+++ b/src/components/Header/styles.module.css
@@ -84,4 +84,5 @@
 .container {
   display: flex;
   gap: 1rem;
+  align-items: center;
 }

--- a/src/components/LazyLoader/LazyLoader.tsx
+++ b/src/components/LazyLoader/LazyLoader.tsx
@@ -2,24 +2,7 @@
 
 import { Suspense } from 'react';
 import dynamic from 'next/dynamic';
-import { LoadingOutlined } from '@ant-design/icons';
-import styles from './LazyLoader.module.css';
-
-export function GlobalLoading({
-  message = 'Loading...',
-  size = 48,
-}: {
-  message?: string;
-  size?: number;
-}) {
-  console.log('GlobalLoading rendered:', message);
-  return (
-    <div className={styles.container}>
-      <LoadingOutlined className={styles.icon} style={{ fontSize: size }} />
-      {message && <p className={styles.message}>{message}</p>}
-    </div>
-  );
-}
+import LoadingState from './LoadingState';
 
 interface LazyLoaderProps {
   component: 'RestClientPage' | 'VariablesPage' | 'HistoryPage';
@@ -41,14 +24,12 @@ export default function LazyLoader({
   size = 48,
 }: LazyLoaderProps) {
   const LazyComponent = dynamic(componentImporters[component], {
-    loading: () => <GlobalLoading message={loadingMessage} size={size} />,
+    loading: () => <LoadingState message={loadingMessage} size={size} />,
     ssr: true,
   });
 
   return (
-    <Suspense
-      fallback={<GlobalLoading message={suspenseMessage} size={size} />}
-    >
+    <Suspense fallback={<LoadingState message={suspenseMessage} size={size} />}>
       <LazyComponent />
     </Suspense>
   );

--- a/src/components/LazyLoader/LoadingState.module.css
+++ b/src/components/LazyLoader/LoadingState.module.css
@@ -1,0 +1,31 @@
+.section {
+  padding: 24px;
+  min-height: 400px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.card {
+  width: 100%;
+  max-width: 600px;
+  text-align: center;
+}
+
+.loading-container {
+  padding: 60px 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+}
+
+.icon {
+  color: #1890ff;
+}
+
+.message {
+  margin: 0;
+  color: #666;
+  font-size: 16px;
+}

--- a/src/components/LazyLoader/LoadingState.tsx
+++ b/src/components/LazyLoader/LoadingState.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import React from 'react';
+import { Card, Spin } from 'antd';
+import styles from './LoadingState.module.css';
+
+interface LoadingStateProps {
+  message?: string;
+  size?: number;
+  className?: string;
+}
+
+export default function LoadingState({
+  message = 'Loading...',
+  className = '',
+}: LoadingStateProps) {
+  return (
+    <section className={`${styles.section} ${className}`}>
+      <Card className={styles.card}>
+        <div className={styles['loading-container']}>
+          <Spin size="large" />
+          {message && <p className={styles.message}>{message}</p>}
+        </div>
+      </Card>
+    </section>
+  );
+}

--- a/src/utils/codeGenerator.ts
+++ b/src/utils/codeGenerator.ts
@@ -1,3 +1,6 @@
+// Кэш для хранения сгенерированного кода
+const codeCache = new Map<string, string>();
+
 export function generateCode(
   language: string,
   method: string,
@@ -5,6 +8,15 @@ export function generateCode(
   headers: Record<string, string>,
   body: string
 ): string {
+  // Создаем уникальный ключ для кэша
+  const cacheKey = `${language}-${method}-${url}-${JSON.stringify(headers)}-${body}`;
+
+  // Проверяем кэш перед генерацией
+  const cachedCode = codeCache.get(cacheKey);
+  if (cachedCode !== undefined) {
+    return cachedCode;
+  }
+
   try {
     const variablePattern = /\{\{[^}]+\}\}/;
     if (
@@ -12,31 +24,50 @@ export function generateCode(
       variablePattern.test(JSON.stringify(headers)) ||
       variablePattern.test(body)
     ) {
-      return 'Error: Unresolved variables detected in request parameters. Please make sure all variables are defined.';
+      const errorMsg =
+        'Error: Unresolved variables detected in request parameters. Please make sure all variables are defined.';
+      codeCache.set(cacheKey, errorMsg);
+      return errorMsg;
     }
+
+    let result: string;
 
     switch (language) {
       case 'curl':
-        return generateCurlCode(method, url, headers, body);
+        result = generateCurlCode(method, url, headers, body);
+        break;
       case 'javascript-fetch':
-        return generateJavascriptFetchCode(method, url, headers, body);
+        result = generateJavascriptFetchCode(method, url, headers, body);
+        break;
       case 'javascript-xhr':
-        return generateJavascriptXHRCode(method, url, headers, body);
+        result = generateJavascriptXHRCode(method, url, headers, body);
+        break;
       case 'nodejs':
-        return generateNodeJSCode(method, url, headers, body);
+        result = generateNodeJSCode(method, url, headers, body);
+        break;
       case 'python':
-        return generatePythonCode(method, url, headers, body);
+        result = generatePythonCode(method, url, headers, body);
+        break;
       case 'java':
-        return generateJavaCode(method, url, headers, body);
+        result = generateJavaCode(method, url, headers, body);
+        break;
       case 'csharp':
-        return generateCSharpCode(method, url, headers, body);
+        result = generateCSharpCode(method, url, headers, body);
+        break;
       case 'go':
-        return generateGoCode(method, url, headers, body);
+        result = generateGoCode(method, url, headers, body);
+        break;
       default:
-        return 'Unsupported language';
+        result = 'Unsupported language';
     }
+
+    // Сохраняем результат в кэш
+    codeCache.set(cacheKey, result);
+    return result;
   } catch (_error) {
-    return 'Error generating code';
+    const errorMsg = 'Error generating code';
+    codeCache.set(cacheKey, errorMsg);
+    return errorMsg;
   }
 }
 
@@ -364,4 +395,14 @@ function generateGoCode(
   code += `}`;
 
   return code;
+}
+
+// Функция для очистки кэша (опционально, для управления памятью)
+export function clearCodeCache(): void {
+  codeCache.clear();
+}
+
+// Функция для получения размера кэша (для отладки)
+export function getCodeCacheSize(): number {
+  return codeCache.size;
 }

--- a/src/utils/requestHelpers.ts
+++ b/src/utils/requestHelpers.ts
@@ -5,25 +5,39 @@ export const executeRequest = async (
 ): Promise<ResponseData> => {
   const startTime = Date.now();
 
-  const response = await fetch(request.url, {
-    method: request.method,
-    headers: request.headers,
-    body: request.method === 'GET' ? undefined : request.body,
-  });
+  try {
+    const response = await fetch(request.url, {
+      method: request.method,
+      headers: request.headers,
+      body:
+        request.method === 'GET' || request.method === 'HEAD'
+          ? undefined
+          : request.body,
+    });
 
-  const body = await response.text();
-  const time = Date.now() - startTime;
+    const body = await response.text();
+    const time = Date.now() - startTime;
 
-  const headers: Record<string, string> = {};
-  response.headers.forEach((value, key) => {
-    headers[key] = value;
-  });
+    const headers: Record<string, string> = {};
+    response.headers.forEach((value, key) => {
+      headers[key] = value;
+    });
 
-  return {
-    status: response.status,
-    statusText: response.statusText,
-    headers,
-    body,
-    time,
-  };
+    return {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+      body,
+      time,
+    };
+  } catch (error) {
+    const time = Date.now() - startTime;
+    return {
+      status: 0,
+      statusText: 'Network Error',
+      headers: {},
+      body: error instanceof Error ? error.message : 'Network request failed',
+      time,
+    };
+  }
 };

--- a/src/views/RestClientPage/RestClientPage.tsx
+++ b/src/views/RestClientPage/RestClientPage.tsx
@@ -49,8 +49,10 @@ const RestClientPage = memo(
     });
     const [headers, setHeaders] = useState<Header[]>([]);
 
-    const { response, isLoading, error, execute } = useRequestHandler();
     const { variables } = useVariables();
+    const { response, isLoading, error, execute } = useRequestHandler({
+      variables,
+    });
     const { updateUrl } = useUrlSync();
     const t = useTranslations('RestClientPage');
 
@@ -118,21 +120,6 @@ const RestClientPage = memo(
       }));
     }, [headers]);
 
-    const executeRequest = useCallback(async () => {
-      try {
-        await execute({
-          method: request.method,
-          url: request.url,
-          headers: request.headers,
-          body: request.body,
-        });
-      } catch (err) {
-        const errorMessage =
-          err instanceof Error ? err.message : 'Unknown error';
-        message.error(t('requestFailed') + errorMessage);
-      }
-    }, [request, execute, t]);
-
     const handleExecute = useCallback(async () => {
       if (!request.url.trim()) {
         message.error(t('inputError'));
@@ -148,26 +135,20 @@ const RestClientPage = memo(
         setRequest((prev) => ({ ...prev, url: requestUrl }));
 
         setTimeout(() => {
-          executeRequest();
+          execute(request);
         }, 100);
         return;
       }
 
       try {
-        await execute({
-          method: request.method,
-          url: requestUrl,
-          headers: request.headers,
-          body: request.body,
-        });
-
+        await execute(request);
         message.success(t('requestSuccess'));
       } catch (err) {
         const errorMessage =
           err instanceof Error ? err.message : 'Unknown error';
         message.error(t('requestFailed') + errorMessage);
       }
-    }, [request, execute, executeRequest, t]);
+    }, [request, execute, t]);
 
     const updateRequest = useCallback((updates: Partial<RequestData>) => {
       setRequest((prev) => ({ ...prev, ...updates }));

--- a/src/views/RestClientPage/RestClientPage.tsx
+++ b/src/views/RestClientPage/RestClientPage.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState, useEffect, useCallback, memo } from 'react';
-import { Card, Typography, message, Spin } from 'antd';
+import { Card, Typography, message } from 'antd';
 import { useLocale, useTranslations } from 'next-intl';
 import styles from './RestClient.module.css';
 
@@ -175,18 +175,6 @@ const RestClientPage = memo(
       },
       [updateRequest]
     );
-
-    if (!isMounted) {
-      return (
-        <section className={styles.section}>
-          <Card className={styles.card}>
-            <div className={styles['loading-container']}>
-              <Spin size="large" />
-            </div>
-          </Card>
-        </section>
-      );
-    }
 
     return (
       <section className={styles.section}>

--- a/src/views/RestClientPage/RestClientPage.tsx
+++ b/src/views/RestClientPage/RestClientPage.tsx
@@ -14,7 +14,7 @@ import VariablesInfo from './components/VariablesInfo/VariablesInfo';
 import { useRequestHandler } from './hooks/useRequestHandler';
 import { useVariables } from './hooks/useVariables';
 import { useUrlSync } from './hooks/useUrlSync';
-import { RequestData, Header } from './types';
+import { RequestData, Header, ResponseData } from './types';
 import {
   headersArrayToObject,
   headersObjectToArray,
@@ -50,11 +50,29 @@ const RestClientPage = memo(
     const [headers, setHeaders] = useState<Header[]>([]);
 
     const { variables } = useVariables();
+    const t = useTranslations('RestClientPage');
+
+    const handleResult = useCallback(
+      (result: ResponseData) => {
+        if (result.status >= 400 || result.status === 0) {
+          const errorMsg =
+            result.status === 0
+              ? `Network Error: ${result.body}`
+              : `HTTP ${result.status}: ${result.statusText || 'Request failed'}`;
+
+          message.error(t('requestFailed') + errorMsg);
+        } else {
+          message.success(t('requestSuccess'));
+        }
+      },
+      [t]
+    );
+
     const { response, isLoading, error, execute } = useRequestHandler({
       variables,
     });
+
     const { updateUrl } = useUrlSync();
-    const t = useTranslations('RestClientPage');
 
     useEffect(() => {
       setIsMounted(true);
@@ -135,20 +153,13 @@ const RestClientPage = memo(
         setRequest((prev) => ({ ...prev, url: requestUrl }));
 
         setTimeout(() => {
-          execute(request);
+          execute({ ...request, url: requestUrl }).then(handleResult);
         }, 100);
         return;
       }
 
-      try {
-        await execute(request);
-        message.success(t('requestSuccess'));
-      } catch (err) {
-        const errorMessage =
-          err instanceof Error ? err.message : 'Unknown error';
-        message.error(t('requestFailed') + errorMessage);
-      }
-    }, [request, execute, t]);
+      execute(request).then(handleResult);
+    }, [request, execute, t, handleResult]);
 
     const updateRequest = useCallback((updates: Partial<RequestData>) => {
       setRequest((prev) => ({ ...prev, ...updates }));

--- a/src/views/RestClientPage/components/BodyPanel/BodyPanel.tsx
+++ b/src/views/RestClientPage/components/BodyPanel/BodyPanel.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Typography } from 'antd';
+import { useTranslations } from 'next-intl';
 import JsonEditor from '@/components/JsonEditor/JsonEditor';
 import styles from './BodyPanel.module.css';
 
@@ -16,9 +17,11 @@ export default function BodyPanel({
   onChange,
   readOnly,
 }: BodyPanelProps) {
+  const t = useTranslations('RestClientPage');
+
   return (
     <div className={styles['body-panel']}>
-      <Title level={4}>Body</Title>
+      <Title level={4}>{t('body')}</Title>
       <JsonEditor
         value={value}
         onChange={onChange}

--- a/src/views/RestClientPage/components/HeadersPanel/HeadersPanel.tsx
+++ b/src/views/RestClientPage/components/HeadersPanel/HeadersPanel.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Typography } from 'antd';
+import { useTranslations } from 'next-intl';
 import HeadersEditor from '@/components/HeadersEditor/HeadersEditor';
 import { Header } from '../../types';
 import styles from './HeadersPanel.module.css';
@@ -12,9 +13,11 @@ interface HeadersPanelProps {
 }
 
 export default function HeadersPanel({ headers, onChange }: HeadersPanelProps) {
+  const t = useTranslations('RestClientPage');
+
   return (
     <div className={styles['headers-panel']}>
-      <Title level={4}>Headers</Title>
+      <Title level={4}>{t('headers')}</Title>
       <HeadersEditor headers={headers} onChange={onChange} />
     </div>
   );

--- a/src/views/RestClientPage/components/RequestPanel/RequestPanel.tsx
+++ b/src/views/RestClientPage/components/RequestPanel/RequestPanel.tsx
@@ -1,3 +1,4 @@
+// RequestPanel.tsx - небольшая корректировка для использования переводов
 import React, { memo, useCallback } from 'react';
 import { Button, Space } from 'antd';
 import { SendOutlined } from '@ant-design/icons';

--- a/src/views/RestClientPage/components/ResponsePanel/ResponsePanel.module.css
+++ b/src/views/RestClientPage/components/ResponsePanel/ResponsePanel.module.css
@@ -9,3 +9,19 @@
 .response-info > * {
   margin-right: 16px;
 }
+
+.error {
+  color: #ff4d4f;
+}
+
+.success {
+  color: #52c41a;
+}
+
+.response-info {
+  margin-bottom: 16px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}

--- a/src/views/RestClientPage/components/ResponsePanel/ResponsePanel.tsx
+++ b/src/views/RestClientPage/components/ResponsePanel/ResponsePanel.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Typography, Alert } from 'antd';
+import { useTranslations } from 'next-intl';
 import JsonEditor from '@/components/JsonEditor/JsonEditor';
 import { ResponseData } from '../../types';
 import styles from './ResponsePanel.module.css';
@@ -17,6 +18,7 @@ export default function ResponsePanel({
   error,
   isLoading,
 }: ResponsePanelProps) {
+  const t = useTranslations('RestClientPage');
   const responseText = error
     ? `Error: ${error}`
     : response
@@ -25,7 +27,7 @@ export default function ResponsePanel({
 
   return (
     <div className={styles['response-panel']}>
-      <Title level={4}>Response</Title>
+      <Title level={4}>{t('response')}</Title>
 
       {error && (
         <Alert
@@ -63,9 +65,7 @@ export default function ResponsePanel({
       )}
 
       {!response && !error && !isLoading && (
-        <Text type="secondary">
-          No response yet. Send a request to see results.
-        </Text>
+        <Text type="secondary">{t('noResponse')}</Text>
       )}
     </div>
   );

--- a/src/views/RestClientPage/components/ResponsePanel/ResponsePanel.tsx
+++ b/src/views/RestClientPage/components/ResponsePanel/ResponsePanel.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Typography } from 'antd';
+import { Typography, Alert } from 'antd';
 import JsonEditor from '@/components/JsonEditor/JsonEditor';
 import { ResponseData } from '../../types';
 import styles from './ResponsePanel.module.css';
@@ -12,32 +12,61 @@ interface ResponsePanelProps {
   isLoading: boolean;
 }
 
-export default function ResponsePanel({ response, error }: ResponsePanelProps) {
-  const responseText = error ? `Error: ${error}` : response?.body || '';
+export default function ResponsePanel({
+  response,
+  error,
+  isLoading,
+}: ResponsePanelProps) {
+  const responseText = error
+    ? `Error: ${error}`
+    : response
+      ? response.body
+      : '';
 
   return (
     <div className={styles['response-panel']}>
       <Title level={4}>Response</Title>
 
+      {error && (
+        <Alert
+          message="Error"
+          description={error}
+          type="error"
+          showIcon
+          style={{ marginBottom: 16 }}
+        />
+      )}
+
       {response && (
         <div className={styles['response-info']}>
           <Text strong>Status: </Text>
-          <Text code>
+          <Text
+            code
+            className={response.status >= 400 ? styles.error : styles.success}
+          >
             {response.status} {response.statusText}
           </Text>
           <Text strong>Time: </Text>
           <Text code>{response.time}ms</Text>
           <Text strong>Size: </Text>
-          <Text code>{response.body.length} bytes</Text>
+          <Text code>{response.body?.length || 0} bytes</Text>
         </div>
       )}
 
-      <JsonEditor
-        value={responseText}
-        onChange={() => {}}
-        readOnly={true}
-        height="300px"
-      />
+      {(response || error) && (
+        <JsonEditor
+          value={responseText}
+          onChange={() => {}}
+          readOnly={true}
+          height="300px"
+        />
+      )}
+
+      {!response && !error && !isLoading && (
+        <Text type="secondary">
+          No response yet. Send a request to see results.
+        </Text>
+      )}
     </div>
   );
 }

--- a/src/views/RestClientPage/components/VariablesInfo/VariablesInfo.tsx
+++ b/src/views/RestClientPage/components/VariablesInfo/VariablesInfo.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Typography } from 'antd';
+import { useTranslations } from 'next-intl';
 import { Variable, hasVariables } from '@/utils/variablesUtils';
 import styles from './VariablesInfo.module.css';
 
@@ -18,6 +19,7 @@ export default function VariablesInfo({
   body,
   variables,
 }: VariablesInfoProps) {
+  const t = useTranslations('RestClientPage');
   const availableVariables =
     variables.map((v) => `{{${v.name}}}`).join(', ') || 'None';
   const hasVars =
@@ -27,17 +29,17 @@ export default function VariablesInfo({
 
   return (
     <div className={styles['variables-info']}>
-      <Title level={4}>Variables Information</Title>
+      <Title level={4}>{t('variablesInfo')}</Title>
       <Text type="secondary">
-        Use variables with format: <code>{'{{variableName}}'}</code>
+        {t('variablesFormat')} <code>{'{{variableName}}'}</code>
       </Text>
       <br />
-      <Text type="secondary">Available variables: {availableVariables}</Text>
+      <Text type="secondary">
+        {t('availableVariables')} {availableVariables}
+      </Text>
       {hasVars && (
         <div className={styles['warning-text']}>
-          <Text type="warning">
-            Contains variables that will be interpolated
-          </Text>
+          <Text type="warning">{t('containsVariables')}</Text>
         </div>
       )}
     </div>

--- a/src/views/RestClientPage/hooks/useRequestHandler.ts
+++ b/src/views/RestClientPage/hooks/useRequestHandler.ts
@@ -6,9 +6,15 @@ import { Variable } from '@/utils/variablesUtils';
 
 interface UseRequestHandlerProps {
   variables: Variable[];
+  onSuccess?: (response: ResponseData) => void;
+  onError?: (error: string) => void;
 }
 
-export const useRequestHandler = ({ variables }: UseRequestHandlerProps) => {
+export const useRequestHandler = ({
+  variables,
+  onSuccess,
+  onError,
+}: UseRequestHandlerProps) => {
   const [response, setResponse] = useState<ResponseData>();
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string>();
@@ -28,6 +34,7 @@ export const useRequestHandler = ({ variables }: UseRequestHandlerProps) => {
     async (request: RequestData) => {
       setIsLoading(true);
       setError(undefined);
+      setResponse(undefined);
 
       try {
         const interpolatedRequest = {
@@ -39,22 +46,38 @@ export const useRequestHandler = ({ variables }: UseRequestHandlerProps) => {
 
         const result = await executeRequest(interpolatedRequest);
 
-        if (result.status === 0) {
-          throw new Error(result.body || 'Network connection failed');
+        if (result.status >= 400 || result.status === 0) {
+          const errorMessage =
+            result.status === 0
+              ? `Network Error: ${result.body}`
+              : `HTTP ${result.status}: ${result.statusText || 'Request failed'}`;
+
+          setError(errorMessage);
+          onError?.(errorMessage);
+        } else {
+          setResponse(result);
+          onSuccess?.(result);
         }
 
-        setResponse(result);
         return result;
       } catch (err) {
         const errorMessage =
           err instanceof Error ? err.message : 'Unknown error';
         setError(errorMessage);
-        throw new Error(errorMessage);
+        onError?.(errorMessage);
+
+        return {
+          status: 0,
+          statusText: 'Exception',
+          headers: {},
+          body: errorMessage,
+          time: 0,
+        };
       } finally {
         setIsLoading(false);
       }
     },
-    [variables]
+    [variables, onSuccess, onError]
   );
 
   return { response, isLoading, error, execute };

--- a/src/views/RestClientPage/hooks/useRequestHandler.ts
+++ b/src/views/RestClientPage/hooks/useRequestHandler.ts
@@ -1,33 +1,61 @@
 import { useState, useCallback } from 'react';
 import { RequestData, ResponseData } from '../types';
 import { executeRequest } from '@/utils/requestHelpers';
+import { interpolateVariables } from '@/utils/variablesUtils';
+import { Variable } from '@/utils/variablesUtils';
 
-export const useRequestHandler = () => {
+interface UseRequestHandlerProps {
+  variables: Variable[];
+}
+
+export const useRequestHandler = ({ variables }: UseRequestHandlerProps) => {
   const [response, setResponse] = useState<ResponseData>();
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string>();
 
-  const execute = useCallback(async (request: RequestData) => {
-    setIsLoading(true);
-    setError(undefined);
+  const interpolateObjectVariables = (
+    obj: Record<string, string>,
+    variables: Variable[]
+  ): Record<string, string> => {
+    const result: Record<string, string> = {};
+    Object.entries(obj).forEach(([key, value]) => {
+      result[key] = interpolateVariables(value, variables);
+    });
+    return result;
+  };
 
-    try {
-      const result = await executeRequest(request);
+  const execute = useCallback(
+    async (request: RequestData) => {
+      setIsLoading(true);
+      setError(undefined);
 
-      if (result.status === 0) {
-        throw new Error(result.body || 'Network connection failed');
+      try {
+        const interpolatedRequest = {
+          method: request.method,
+          url: interpolateVariables(request.url, variables),
+          headers: interpolateObjectVariables(request.headers, variables),
+          body: interpolateVariables(request.body, variables),
+        };
+
+        const result = await executeRequest(interpolatedRequest);
+
+        if (result.status === 0) {
+          throw new Error(result.body || 'Network connection failed');
+        }
+
+        setResponse(result);
+        return result;
+      } catch (err) {
+        const errorMessage =
+          err instanceof Error ? err.message : 'Unknown error';
+        setError(errorMessage);
+        throw new Error(errorMessage);
+      } finally {
+        setIsLoading(false);
       }
-
-      setResponse(result);
-      return result;
-    } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : 'Unknown error';
-      setError(errorMessage);
-      throw new Error(errorMessage);
-    } finally {
-      setIsLoading(false);
-    }
-  }, []);
+    },
+    [variables]
+  );
 
   return { response, isLoading, error, execute };
 };


### PR DESCRIPTION
Вроде все сделал:

RESTful client
- Functional editor enabling query editing and prettifying, request body provided in the URL as base64-encoded on request submit. - 35 points
- Functional read-only response section, with information about HTTP status and the code. - 30 points
 - Method selector, shows all the valid HTTP verbs, value is provided in the URL on request submit. - 15 points
 - Input for the URL, entered value is provided in base64-encoded way on request submit. - 20 points
-  Headers section, value is provided in the URL on request submit. - 20 points
-  Code generation section. - 30 points

This route should be private.
Rest client code should be lazy-loaded (so unauthenticated user won't download the code).
Header should be visible.
Method selector. Selected method should be reflected in the application URL (e.g. http://restclient.com/GET), for more details, please, check the next section.
Endpoint (URL) input.
Request body editor / JSON viewer. It will be used in the response section in read-only mode. Should support prettifying. Please, mind that request body editor should support at least JSON and plain text. Support of the XML syntax is not mandatory.
Headers editor section.
Generated code section.
Response section. Should be read-only. Should contain information about HTTP response code and the response status.